### PR TITLE
Adjust to changes in Amecs API 1.3.3

### DIFF
--- a/src/main/java/de/klotzi111/ktig/impl/mixin/keybinding/amecsapi/MixinMouse.java
+++ b/src/main/java/de/klotzi111/ktig/impl/mixin/keybinding/amecsapi/MixinMouse.java
@@ -117,7 +117,7 @@ public class MixinMouse {
 		return decValAndReset(d);
 	}
 
-	@Inject(method = "onMouseScroll", at = @At(value = "INVOKE", shift = Shift.AFTER, target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDD)Z", ordinal = 0), locals = LocalCapture.CAPTURE_FAILSOFT)
+	@Inject(method = "onMouseScroll", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDD)Z", ordinal = 0), locals = LocalCapture.CAPTURE_FAILSOFT)
 	private void injection_NON_SCREEN_PROCESSED(long window, double horizontal, double vertical, CallbackInfo ci, double deltaY) {
 		if (((IMouse) this).amecs$getMouseScrolledEventUsed()) {
 			return;
@@ -131,7 +131,7 @@ public class MixinMouse {
 	}
 
 	// does not actually affect anything because the method ends after this. But if it is here for compatibility with other mods
-	@ModifyVariable(method = "onMouseScroll", at = @At(value = "INVOKE", shift = Shift.AFTER, target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDD)Z", ordinal = 0), ordinal = 2)
+	@ModifyVariable(method = "onMouseScroll", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDD)Z", ordinal = 0), ordinal = 2)
 	private double after_NON_SCREEN_PROCESSED(double d) {
 		return decValAndReset(d);
 	}


### PR DESCRIPTION
Siphalor/amecs-api@b51f807d1be6e026f8c391123c2bed3d90799f95 introduced some changes in the approach to `MixinMouse`.

To be exact the `@Redirect` used previously caused a conflict with jGui. 
This has now been mitigated by doing bytecode manipulation to capture the return value of `mouseScrolled` and do a normal injection.

Since KTIG seems to rely on the exact injection point that Amecs uses, it needs to switch from `INVOKE` to `INVOKE_ASSIGN` accordingly.

*This pull request is untested.*